### PR TITLE
🎉 Release 0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## [0.0.1](https://github.com/CrystalNET-org/grpc-ffmpeg/releases/tag/0.0.1) - 2024-10-21
+
+### ❤️ Thanks to all contributors! ❤️
+
+@psych0d0g
+
+### Misc
+
+- Configure Renovate [[#1](https://github.com/CrystalNET-org/grpc-ffmpeg/pull/1)]
+- Configure Renovate [[#1](https://github.com/CrystalNET-org/grpc-ffmpeg/pull/1)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,5 +8,9 @@
 
 ### Misc
 
+- Update harbor.crystalnet.org/dockerhub-proxy/woodpeckerci/plugin-git Docker tag to v2.6.0 [[#4](https://github.com/CrystalNET-org/grpc-ffmpeg/pull/4)]
+- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.440.7 [[#3](https://github.com/CrystalNET-org/grpc-ffmpeg/pull/3)]
+- Update harbor.crystalnet.org/dockerhub-proxy/woodpeckerci/plugin-git Docker tag to v2.6.0 [[#4](https://github.com/CrystalNET-org/grpc-ffmpeg/pull/4)]
+- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.440.7 [[#3](https://github.com/CrystalNET-org/grpc-ffmpeg/pull/3)]
 - Configure Renovate [[#1](https://github.com/CrystalNET-org/grpc-ffmpeg/pull/1)]
 - Configure Renovate [[#1](https://github.com/CrystalNET-org/grpc-ffmpeg/pull/1)]


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `0.0.1` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [0.0.1](https://github.com/CrystalNET-org/grpc-ffmpeg/releases/tag/0.0.1) - 2024-10-21

### Misc

- Update harbor.crystalnet.org/dockerhub-proxy/woodpeckerci/plugin-git Docker tag to v2.6.0 [[#4](https://github.com/CrystalNET-org/grpc-ffmpeg/pull/4)]
- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.440.7 [[#3](https://github.com/CrystalNET-org/grpc-ffmpeg/pull/3)]
- Update harbor.crystalnet.org/dockerhub-proxy/woodpeckerci/plugin-git Docker tag to v2.6.0 [[#4](https://github.com/CrystalNET-org/grpc-ffmpeg/pull/4)]
- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.440.7 [[#3](https://github.com/CrystalNET-org/grpc-ffmpeg/pull/3)]
- Configure Renovate [[#1](https://github.com/CrystalNET-org/grpc-ffmpeg/pull/1)]
- Configure Renovate [[#1](https://github.com/CrystalNET-org/grpc-ffmpeg/pull/1)]