### PR TITLE
🎉 Release 7.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [7.0.2](https://github.com/CrystalNET-org/grpc-ffmpeg/releases/tag/7.0.2) - 2024-10-27
+## [7.0.2](https://github.com/CrystalNET-org/grpc-ffmpeg/releases/tag/7.0.2) - 2024-10-28
 
 ### ❤️ Thanks to all contributors! ❤️
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Misc
 
+- 🎉 Release 0.0.1 [[#2](https://github.com/CrystalNET-org/grpc-ffmpeg/pull/2)]
+- 🎉 Release 0.0.1 [[#2](https://github.com/CrystalNET-org/grpc-ffmpeg/pull/2)]
 - Update harbor.crystalnet.org/dockerhub-proxy/woodpeckerci/plugin-git Docker tag to v2.6.0 [[#4](https://github.com/CrystalNET-org/grpc-ffmpeg/pull/4)]
 - Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.440.7 [[#3](https://github.com/CrystalNET-org/grpc-ffmpeg/pull/3)]
 - Update harbor.crystalnet.org/dockerhub-proxy/woodpeckerci/plugin-git Docker tag to v2.6.0 [[#4](https://github.com/CrystalNET-org/grpc-ffmpeg/pull/4)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [7.0.2](https://github.com/CrystalNET-org/grpc-ffmpeg/releases/tag/7.0.2) - 2024-11-19
+## [7.0.2](https://github.com/CrystalNET-org/grpc-ffmpeg/releases/tag/7.0.2) - 2024-11-20
 
 ### ❤️ Thanks to all contributors! ❤️
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [7.0.2](https://github.com/CrystalNET-org/grpc-ffmpeg/releases/tag/7.0.2) - 2024-10-27
+
+### ❤️ Thanks to all contributors! ❤️
+
+@psych0d0g
+
+### Misc
+
+- Update woodpeckerci/plugin-docker-buildx Docker tag to v2.3.0 [[#6](https://github.com/CrystalNET-org/grpc-ffmpeg/pull/6)]
+
 ## [6.0.1](https://github.com/CrystalNET-org/grpc-ffmpeg/releases/tag/6.0.1) - 2024-10-27
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [7.0.2](https://github.com/CrystalNET-org/grpc-ffmpeg/releases/tag/7.0.2) - 2024-10-28
+## [7.0.2](https://github.com/CrystalNET-org/grpc-ffmpeg/releases/tag/7.0.2) - 2024-11-19
 
 ### ❤️ Thanks to all contributors! ❤️
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [6.0.1](https://github.com/CrystalNET-org/grpc-ffmpeg/releases/tag/6.0.1) - 2024-10-27
+
+### ❤️ Thanks to all contributors! ❤️
+
+@psych0d0g
+
+### Misc
+
+- Update woodpeckerci/plugin-docker-buildx Docker tag to v2.3.0 [[#6](https://github.com/CrystalNET-org/grpc-ffmpeg/pull/6)]
+
 ## [0.0.1](https://github.com/CrystalNET-org/grpc-ffmpeg/releases/tag/0.0.1) - 2024-10-21
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `7.0.2` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [7.0.2](https://github.com/CrystalNET-org/grpc-ffmpeg/releases/tag/7.0.2) - 2024-11-20

### Misc

- Update woodpeckerci/plugin-docker-buildx Docker tag to v2.3.0 [[#6](https://github.com/CrystalNET-org/grpc-ffmpeg/pull/6)]